### PR TITLE
Added option to always publish values

### DIFF
--- a/modbus2mqtt.py
+++ b/modbus2mqtt.py
@@ -68,6 +68,7 @@ parser.add_argument('--config', required=True, help='Configuration file. Require
 parser.add_argument('--verbosity', default='3', type=int, help='Verbose level, 0=silent, 1=errors only, 2=connections, 3=mb writes, 4=all')
 parser.add_argument('--autoremove',action='store_true',help='Automatically remove poller if modbus communication has failed three times. Removed pollers can be reactivated by sending "True" or "1" to topic modbus/reset-autoremove')
 parser.add_argument('--add-to-homeassistant',action='store_true',help='Add devices to Home Assistant using Home Assistant\'s MQTT-Discovery')
+parser.add_argument('--always-publish',action='store_true',help='Always publish values, even if they did not change.')
 parser.add_argument('--set-loop-break',default='0.01',type=float, help='Set pause in main polling loop. Defaults to 10ms.')
 parser.add_argument('--diagnostics-rate',default='0',type=int, help='Time in seconds after which for each device diagnostics are published via mqtt. Set to sth. like 600 (= every 10 minutes) or so.')
 
@@ -538,7 +539,7 @@ class Reference:
         # but only after the intial connection was made.
         if mqc.initial_connection_made == True:
             val = self.dtype.combine(val)
-            if self.lastval != val:
+            if self.lastval != val or args.always_publish:
                 self.lastval = val
                 if self.scale:
                     val = val * self.scale

--- a/modbus2mqtt.py
+++ b/modbus2mqtt.py
@@ -457,7 +457,13 @@ class Reference:
         self.topic=topic
         self.reference=int(reference)
         self.lastval=None
-        self.scale=scaling
+        self.scale=None
+        if scaling:
+            try:
+                self.scale=float(scaling)
+            except ValueError as e:
+              if verbosity>=1:
+                print("Scaling Error:", e)
         self.rw=rw
         self.relativeReference=None
         self.writefunctioncode=None
@@ -486,7 +492,7 @@ class Reference:
             if self.lastval != val:
                 self.lastval = val
                 if self.scale:
-                  val = val * float(self.scale)
+                    val = val * self.scale
                 try:
                     publish_result = mqc.publish(globaltopic+self.device.name+"/state/"+self.topic,val,retain=True)
                     if verbosity>=4:

--- a/modbus2mqtt.py
+++ b/modbus2mqtt.py
@@ -453,10 +453,11 @@ class dataTypes:
 
 
 class Reference:
-    def __init__(self,topic,reference,dtype,rw,poller):
+    def __init__(self,topic,reference,dtype,rw,poller,scaling):
         self.topic=topic
         self.reference=int(reference)
         self.lastval=None
+        self.scale=scaling
         self.rw=rw
         self.relativeReference=None
         self.writefunctioncode=None
@@ -484,8 +485,10 @@ class Reference:
             val = self.dtype.combine(val)
             if self.lastval != val:
                 self.lastval = val
+                if self.scale:
+                  val = val * float(self.scale)
                 try:
-                    publish_result = mqc.publish(globaltopic+self.device.name+"/state/"+self.topic,self.lastval,retain=True)
+                    publish_result = mqc.publish(globaltopic+self.device.name+"/state/"+self.topic,val,retain=True)
                     if verbosity>=4:
                         print("published MQTT topic: " + str(self.device.name+"/state/"+self.topic)+" value: " + str(self.lastval)+" RC:"+str(publish_result.rc))
                 except:
@@ -551,7 +554,7 @@ with open(args.config,"r") as csvfile:
             continue
         elif row["type"]=="reference" or row["type"]=="ref":
             if currentPoller is not None:
-                currentPoller.addReference(Reference(row["topic"],row["col2"],row["col4"],row["col3"],currentPoller))
+                currentPoller.addReference(Reference(row["topic"],row["col2"],row["col4"],row["col3"],currentPoller,row["col5"]))
             else:
                 print("No poller for reference "+row["topic"]+".")
 


### PR DESCRIPTION
For some applications the default behavior of only publishing changed references is not desirable.

Adding `--always-publish` as an option to always publish all values even if they did not change.