### PR TITLE
Update MQTT host

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you've installed using pip:
 * example for rtu and mqtt broker on localhost: `modbus2mqtt --rtu /dev/ttyS0 --rtu-baud 38400 --rtu-parity none --mqtt-host localhost  --config testing.csv`
 * example for tcp slave and mqtt broker
     on localhost: `modbus2mqtt --tcp localhost --config testing.csv`
-    remotely: `modbus2mqtt --tcp 192.168.1.7 --config example.csv --mqtt-host iot.eclipse.org`
+    remotely: `modbus2mqtt --tcp 192.168.1.7 --config example.csv --mqtt-host mqtt.eclipseprojects.io`
 
 
 If you haven't installed modbus2mqtt you can run modbus2mqtt.py from the root directory of this repo directly:
@@ -90,7 +90,7 @@ If you haven't installed modbus2mqtt you can run modbus2mqtt.py from the root di
 * example for rtu and mqtt broker on localhost: `python3 modbus2mqtt.py --rtu /dev/ttyS0 --rtu-baud 38400 --rtu-parity none --mqtt-host localhost  --config testing.csv`
 * example for tcp slave and mqtt broker
     on localhost: `python3 modbus2mqtt.py --tcp localhost --config testing.csv`
-    remotely:     `python3 modbus2mqtt.py --tcp 192.168.1.7 --config example.csv --mqtt-host iot.eclipse.org`
+    remotely:     `python3 modbus2mqtt.py --tcp 192.168.1.7 --config example.csv --mqtt-host mqtt.eclipseprojects.io`
 
 For docker support see below.
      


### PR DESCRIPTION
Replace failing MQTT host iot.eclipse.org with working host mqtt.eclipseprojects.io