### PR TITLE
Get dockerbuild running again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 FROM python:alpine
+
 WORKDIR /app
+
 COPY modbus2mqtt.py ./
 COPY modbus2mqtt modbus2mqtt/
+
 RUN mkdir -p /app/conf/
-RUN pip install --root-user-action=ignore --no-cache-dir pymodbus
-RUN pip install --root-user-action=ignore --no-cache-dir paho-mqtt
-ENTRYPOINT ["python","-u","./modbus2mqtt.py","--config","/app/conf/modbus2mqtt.csv"]
+
+# upgrade pip to avoid warnings during the docker build
+RUN pip3 install --root-user-action=ignore --upgrade pip
+
+# ensure we have the version 2.5.3 of pymodbus installed
+RUN pip3 install --root-user-action=ignore --no-cache-dir pymodbus==2.5.3
+RUN pip3 install --root-user-action=ignore --no-cache-dir paho-mqtt
+
+ENTRYPOINT [ "python", "-u", "./modbus2mqtt.py", "--config", "/app/conf/modbus2mqtt.csv" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ COPY modbus2mqtt modbus2mqtt/
 RUN mkdir -p /app/conf/
 
 # upgrade pip to avoid warnings during the docker build
-RUN pip3 install --root-user-action=ignore --upgrade pip
+RUN pip install --root-user-action=ignore --upgrade pip
 
 # ensure we have the version 2.5.3 of pymodbus installed
-RUN pip3 install --root-user-action=ignore --no-cache-dir pymodbus==2.5.3
-RUN pip3 install --root-user-action=ignore --no-cache-dir paho-mqtt
+RUN pip install --root-user-action=ignore --no-cache-dir pymodbus==2.5.3
+RUN pip install --root-user-action=ignore --no-cache-dir paho-mqtt
 
 ENTRYPOINT [ "python", "-u", "./modbus2mqtt.py", "--config", "/app/conf/modbus2mqtt.csv" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY modbus2mqtt.py ./
 COPY modbus2mqtt modbus2mqtt/
 RUN mkdir -p /app/conf/
-RUN pip install --no-cache-dir pymodbus
-RUN pip install --no-cache-dir paho-mqtt
+RUN pip install --root-user-action=ignore --no-cache-dir pymodbus
+RUN pip install --root-user-action=ignore --no-cache-dir paho-mqtt
 ENTRYPOINT ["python","-u","./modbus2mqtt.py","--config","/app/conf/modbus2mqtt.csv"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you've installed using pip:
 * example for rtu and mqtt broker on localhost: `modbus2mqtt --rtu /dev/ttyS0 --rtu-baud 38400 --rtu-parity none --mqtt-host localhost  --config testing.csv`
 * example for tcp slave and mqtt broker
     on localhost: `modbus2mqtt --tcp localhost --config testing.csv`
-    remotely: `modbus2mqtt --tcp 192.168.1.7 --config example.csv --mqtt-host iot.eclipse.org`
+    remotely: `modbus2mqtt --tcp 192.168.1.7 --config example.csv --mqtt-host mqtt.eclipseprojects.io`
 
 
 If you haven't installed modbus2mqtt you can run modbus2mqtt.py from the root directory of this repo directly:
@@ -90,7 +90,7 @@ If you haven't installed modbus2mqtt you can run modbus2mqtt.py from the root di
 * example for rtu and mqtt broker on localhost: `python3 modbus2mqtt.py --rtu /dev/ttyS0 --rtu-baud 38400 --rtu-parity none --mqtt-host localhost  --config testing.csv`
 * example for tcp slave and mqtt broker
     on localhost: `python3 modbus2mqtt.py --tcp localhost --config testing.csv`
-    remotely:     `python3 modbus2mqtt.py --tcp 192.168.1.7 --config example.csv --mqtt-host iot.eclipse.org`
+    remotely:     `python3 modbus2mqtt.py --tcp 192.168.1.7 --config example.csv --mqtt-host mqtt.eclipseprojects.io`
 
 For docker support see below.
      

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ an MQTT message broker is used as the centralized message bus.
 
 Changelog
 ---------
+- version 0.64, 16. of October 2022: Adjustment of the Dockerfile (enforcing pymodbus 2.5.3, otherwise it tries to use 3.0 and this failes); typo fixed; main-/poller-loop log entry
 - version 0.63, 04. of October 2022: added reading and writing of int32 values, fix regarding negative floats
 - version 0.62, 6. of February 2022: major refactoring, project is now python module available via pip
 - version 0.5, 21. of September 2019: print error messages in case of badly configured pollers


### PR DESCRIPTION
Initially I just wanted to get rid of the warning during the docker image build:
```
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```
As this runs inside a container, this warning should be suppressed.

But last night I run into the issue, that the newest pymodbus version stopped the service from running. 
It ended up in this failure:
```
modbus2mqtt    | Traceback (most recent call last):
modbus2mqtt    |   File "/app/./modbus2mqtt.py", line 2, in <module>
modbus2mqtt    |     from  modbus2mqtt.modbus2mqtt import main
modbus2mqtt    |   File "/app/modbus2mqtt/modbus2mqtt.py", line 33, in <module>
modbus2mqtt    |     import serial
modbus2mqtt    | ModuleNotFoundError: No module named 'serial'
```

After adding serial and serial-async, I run into this failure:
```
modbus2mqtt    | Traceback (most recent call last):
modbus2mqtt    |   File "/app/./modbus2mqtt.py", line 2, in <module>
modbus2mqtt    |     from  modbus2mqtt.modbus2mqtt import main
modbus2mqtt    |   File "/app/modbus2mqtt/modbus2mqtt.py", line 46, in <module>
modbus2mqtt    |     from pymodbus.client.sync import ModbusSerialClient as SerialModbusClient
modbus2mqtt    | ModuleNotFoundError: No module named 'pymodbus.client.sync'
```

After some investigation, I found that pymodbus had released a new version 3.0 and after downgrading to the version 2.5.3 it started to work again.