### PR TITLE
Docker: Resolve missing serial module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /app/conf/
 # upgrade pip to avoid warnings during the docker build
 RUN pip install --root-user-action=ignore --upgrade pip
 
-RUN pip install --root-user-action=ignore --no-cache-dir pymodbus
+RUN pip install --root-user-action=ignore --no-cache-dir pyserial pymodbus
 RUN pip install --root-user-action=ignore --no-cache-dir paho-mqtt
 
 ENTRYPOINT [ "python", "-u", "./modbus2mqtt.py", "--config", "/app/conf/modbus2mqtt.csv" ]


### PR DESCRIPTION
Running the service using Docker would result with the error `ModuleNotFoundError: No module named 'serial'`
Adding in missing python module

Linked issue: #20 